### PR TITLE
Externalised verify TOKEN into Heroku config var

### DIFF
--- a/heroku/README.md
+++ b/heroku/README.md
@@ -11,8 +11,8 @@ This is a sample client for [Facebook's Graph API Webhooks](https://developers.f
 
 ### Facebook
 1. Create a new [Facebook application](https://developers.facebook.com/apps).
-1. Set up your Facebook application's [Graph API Webhooks subscription](https://developers.facebook.com/docs/graph-api/webhooks/#setup) using `https://<your-subdomain>.herokuapp.com/facebook` as the callback URL and `token` as the verify_token.
+1. Set up your Facebook application's [Graph API Webhooks subscription](https://developers.facebook.com/docs/graph-api/webhooks/#setup) using `https://<your-subdomain>.herokuapp.com/facebook` as the callback URL. It is recommended that you set a `TOKEN` [config var](https://devcenter.heroku.com/articles/config-vars) as part of the set up of your Heroku app to secure requests. If you choose not to set a config var, then you will need to set a verify token of 'token' when configuring the callback URL.
 
 ### Instagram
 1. Register an [Instagram API client](https://instagram.com/developer/clients/manage/).
-1. Set up your client's [subscription](https://www.instagram.com/developer/subscriptions/) using your `https://<your-subdomain>.herokuapp.com/instagram` as the callback URL and `token` as the verify_token.
+1. Set up your client's [subscription](https://www.instagram.com/developer/subscriptions/) using your `https://<your-subdomain>.herokuapp.com/instagram` as the callback URL. It is recommended that you set a `TOKEN` [config var](https://devcenter.heroku.com/articles/config-vars) as part of the set up of your Heroku app to secure requests. If you choose not to set a config var, then you will need to set a verify token of 'token' when configuring the callback URL.

--- a/heroku/index.js
+++ b/heroku/index.js
@@ -25,10 +25,7 @@ app.get('/', function(req, res) {
   res.send('<pre>' + JSON.stringify(received_updates, null, 2) + '</pre>');
 });
 
-app.get(['/facebook', '/instagram'], function(req, res) {
-  console.log("Expected token = " + token);
-  console.log("Actual token = " + req.param('hub.verify_token'));
-    
+app.get(['/facebook', '/instagram'], function(req, res) {   
   if (
     req.param('hub.mode') == 'subscribe' &&
     req.param('hub.verify_token') == token

--- a/heroku/index.js
+++ b/heroku/index.js
@@ -17,6 +17,7 @@ app.listen(app.get('port'));
 app.use(xhub({ algorithm: 'sha1', secret: process.env.APP_SECRET }));
 app.use(bodyParser.json());
 
+var token = process.env.TOKEN || 'token';
 var received_updates = [];
 
 app.get('/', function(req, res) {
@@ -25,9 +26,12 @@ app.get('/', function(req, res) {
 });
 
 app.get(['/facebook', '/instagram'], function(req, res) {
+  console.log("Expected token = " + token);
+  console.log("Actual token = " + req.param('hub.verify_token'));
+    
   if (
     req.param('hub.mode') == 'subscribe' &&
-    req.param('hub.verify_token') == 'token'
+    req.param('hub.verify_token') == token
   ) {
     res.send(req.param('hub.challenge'));
   } else {


### PR DESCRIPTION
Added ability to read TOKEN property from config var, and updated readme to match. (I managed to confuse myself between the two different "secrets" when following the set up for this, so hopefully this change makes things more explicit)