### PR TITLE
Update typo in link documentation

### DIFF
--- a/heroku/README.md
+++ b/heroku/README.md
@@ -9,7 +9,7 @@ This is a sample client for Facebook's [Webhooks](https://developers.facebook.co
 1. Refer to Facebook's [Webhooks sample app documentation](https://developers.facebook.com/docs/graph-api/webhooks/sample-apps) to see how to use this app.
 1. Deploy the sample app on Heroku with this button:
 
-    [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/fbsamples/graph-api-webhooks-samples/)
+    [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/fbsamples/graph-api-webhooks-samples)
 
 ### Instagram Subscription API
 1. Register an [Instagram API client](https://instagram.com/developer/clients/manage/).

--- a/heroku/README.md
+++ b/heroku/README.md
@@ -9,7 +9,7 @@ This is a sample client for Facebook's [Webhooks](https://developers.facebook.co
 1. Refer to Facebook's [Webhooks sample app documentation](https://developers.facebook.com/docs/graph-api/webhooks/sample-apps) to see how to use this app.
 1. Deploy the sample app on Heroku with this button:
 
-    [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/fbsamples/graph-api-webhooks-samples)
+    [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://www.github.com/fbsamples/graph-api-webhooks-samples)
 
 ### Instagram Subscription API
 1. Register an [Instagram API client](https://instagram.com/developer/clients/manage/).


### PR DESCRIPTION
### Pull Request Description

#### Summary
This pull request updates the Heroku deployment URL in the documentation to resolve the issue with missing `app.json` in the provided repository URL.

#### Changes
- **Updated the Heroku deployment URL**:
   Changed the deployment link from:
   `https://heroku.com/deploy?template=https://github.com/fbsamples/graph-api-webhooks-samples/`
   to:
   `https://heroku.com/deploy?template=https://github.com/fbsamples/graph-api-webhooks-samples`

#### Context
- This modification is necessary because users attempting to deploy the sample app via Heroku were encountering the error message: 
   `"No app.json located in the repo URL provided."`
- The issue is documented in [Issue #34](https://github.com/fbsamples/graph-api-webhooks-samples/issues/34), where user @erickwinz30 reported the problem when trying to deploy the app on Heroku.

#### Instructions
1. Refer to Facebook's [Webhooks sample app documentation](https://developers.facebook.com/docs/graph-api/webhooks/sample-apps) to understand how to use this application.
2. To deploy the sample app on Heroku, use the updated button below:

    [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/fbsamples/graph-api-webhooks-samples)

#### Instagram Subscription API
- If you're working with Instagram, you can register an [Instagram API client](https://instagram.com/developer/clients/manage/) as part of the setup.

This update should resolve the deployment issue by ensuring the correct Heroku template URL is used for proper app configuration.


